### PR TITLE
Fix netlify build on production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,11 @@
-[build]
-publish = "public"
-command = "yarn build -- -b ${DEPLOY_URL}"
-
 [build.environment]
 HUGO_VERSION = "0.139.3"
 GO_VERSION = "1.23.4"
+
+[context.production]
+publish = "public"
+command = "yarn build"
+
+[context.deploy-preview]
+publish = "public"
+command = "yarn build -- -b ${DEPLOY_URL}"


### PR DESCRIPTION
Tentative 1

Deploy-preview need a specific URL to be set. However, the variable is not properly set in production but is set to the commit URL.
